### PR TITLE
Add CI workflows for apt-source

### DIFF
--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -60,7 +60,7 @@ jobs:
         run: | 
               earthly +ros2-test-repos --distro=${{ matrix.distro }}
               earthly +ros2-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
-              earthly +integration-check-switch: --distro=${{ matrix.distro }}
+              earthly +integration-check-switch --distro=${{ matrix.distro }}
   ros-ci:
     runs-on: ubuntu-latest
     strategy:
@@ -79,4 +79,4 @@ jobs:
         run: | 
               earthly +ros-test-repos --distro=${{ matrix.distro }}
               earthly +ros-test-repos --distro=${{ matrix.distro }} --package=ros-testing-apt-source
-              earthly +integration-check-switch: --distro=${{ matrix.distro }} --repo=ros
+              earthly +integration-check-switch --distro=${{ matrix.distro }} --repo=ros

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -1,4 +1,4 @@
-name: Build Variants
+name: Build keyring
 
 on:
   push:
@@ -28,10 +28,10 @@ jobs:
           sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build apt-source deb
-        run: earthly +build-ros-apt-source
+        run: earthly +build-ros-apt-source --distro=${{ matrix.distro }}
       - name: Test apt-source deb 
         run:  | 
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.version }}
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }}
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -1,4 +1,4 @@
-name: Build keyring
+name: Build packages
 
 on:
   push:
@@ -41,6 +41,7 @@ jobs:
     strategy:
       matrix:
         distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
+    needs: [build-keyring, build-apt-source]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -40,8 +40,8 @@ jobs:
         run: earthly +ros-apt-source --distro=${{ matrix.distro }}
       - name: Test ros 2 apt-source deb 
         run:  | 
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros-testing
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros --version=ros
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros-testing --version=ros
   ros2-ci:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -24,6 +24,8 @@ jobs:
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros2
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros2-testing
+
+  build-ros-apt-source:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Build keyring deb
         run: earthly +ros-archive-keyring
       - name: Test keyring deb
-        run: earthly +ros-archive-keyring
+        run: earthly +test-keyring-pkg-install
   build-apt-source:
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +41,6 @@ jobs:
     strategy:
       matrix:
         distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
-    needs: [build-keyring, build-apt-source]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -49,4 +48,7 @@ jobs:
           sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
       - name: Test integration
-        run: earthly +all-integration-tests --distro=${{ matrix.distro }}
+        run: | 
+              earthly +build-ros-apt-source --distro=${{ matrix.distro }}
+              earthly +ros-archive-keyring
+              earthly +all-integration-tests --distro=${{ matrix.distro }}

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Test ros 2 apt-source deb 
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true --repo-ros
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true --repo=ros
   ros2-ci:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -47,8 +47,10 @@ jobs:
         run: |
           sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
-      - name: Test integration
+      - name: Build packages integration
         run: | 
               earthly +build-ros-apt-source --distro=${{ matrix.distro }}
               earthly +ros-archive-keyring
+      - name: Test integration
+        run: | 
               earthly +all-integration-tests --distro=${{ matrix.distro }}

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -7,18 +7,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-keyring:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Earthly
-        run: |
-          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
-          sudo chmod 755 /usr/local/bin/earthly
-      - name: Build keyring deb
-        run: earthly +ros-archive-keyring
-      - name: Test keyring deb
-        run: earthly +test-keyring-pkg-install
   build-apt-source:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -22,9 +22,8 @@ jobs:
         run: earthly +ros-apt-source --distro=${{ matrix.distro }}
       - name: Test ros 2 apt-source deb 
         run:  | 
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }}
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true
-  build-ros-apt-source:
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros2
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros2-testing
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,7 +39,7 @@ jobs:
       - name: Test ros 2 apt-source deb 
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros
-              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true --repo=ros
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros-testing
   ros2-ci:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -1,0 +1,48 @@
+name: Build Variants
+
+on:
+  push:
+    branches: ["latest"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-keyring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build keyring deb
+        run: earthly +ros-archive-keyring
+      - name: Test keyring deb
+        run: earthly +ros-archive-keyring
+  build-apt-source:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build apt-source deb
+        run: earthly +build-ros-apt-source
+      - name: Test apt-source deb 
+        run:  | 
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.version }}
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Test integration
+        run: earthly +all-integration-tests --distro=${{ matrix.distro }}

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -21,6 +21,9 @@ jobs:
         run: earthly +ros-archive-keyring
   build-apt-source:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -54,7 +54,7 @@ jobs:
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build packages integration
         run: | 
-              earthly +build-ros-apt-source --distro=${{ matrix.distro }}
+              earthly +ros-apt-source --distro=${{ matrix.distro }}
       - name: Test integration
         run: | 
               earthly +ros2-test-repos --distro=${{ matrix.distro }}
@@ -73,7 +73,7 @@ jobs:
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build packages integration
         run: | 
-              earthly +build-ros-apt-source --distro=${{ matrix.distro }}
+              earthly +ros-apt-source --distro=${{ matrix.distro }}
       - name: Test integration
         run: | 
               earthly +ros-test-repos --distro=${{ matrix.distro }}

--- a/.github/workflows/build-test-packages.yaml
+++ b/.github/workflows/build-test-packages.yaml
@@ -7,11 +7,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-apt-source:
+  build-ros2-apt-source:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -19,16 +19,33 @@ jobs:
           sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
           sudo chmod 755 /usr/local/bin/earthly
       - name: Build apt-source deb
-        run: earthly +build-ros-apt-source --distro=${{ matrix.distro }}
-      - name: Test apt-source deb 
+        run: earthly +ros-apt-source --distro=${{ matrix.distro }}
+      - name: Test ros 2 apt-source deb 
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }}
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true
-  ci:
+  build-ros-apt-source:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian:bullseye,debian:bookworm,ubuntu:jammy,ubuntu:noble ]
+        distro: [ubuntu:focal]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build apt-source deb
+        run: earthly +ros-apt-source --distro=${{ matrix.distro }}
+      - name: Test ros 2 apt-source deb 
+        run:  | 
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros
+              earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --testing=true --repo-ros
+  ros2-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -38,7 +55,27 @@ jobs:
       - name: Build packages integration
         run: | 
               earthly +build-ros-apt-source --distro=${{ matrix.distro }}
-              earthly +ros-archive-keyring
       - name: Test integration
         run: | 
-              earthly +all-integration-tests --distro=${{ matrix.distro }}
+              earthly +ros2-test-repos --distro=${{ matrix.distro }}
+              earthly +ros2-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
+              earthly +integration-check-switch: --distro=${{ matrix.distro }}
+  ros-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [ubuntu:focal]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build packages integration
+        run: | 
+              earthly +build-ros-apt-source --distro=${{ matrix.distro }}
+      - name: Test integration
+        run: | 
+              earthly +ros-test-repos --distro=${{ matrix.distro }}
+              earthly +ros-test-repos --distro=${{ matrix.distro }} --package=ros-testing-apt-source
+              earthly +integration-check-switch: --distro=${{ matrix.distro }} --repo=ros

--- a/Earthfile
+++ b/Earthfile
@@ -47,12 +47,11 @@ test-aptsource-pkg-install:
   # Test that apt source package is installable and that it configures the necessary files
   ARG distro = ubuntu:noble
   ARG repo = ros2
-
+  ARG version = ros2
   FROM ${distro}
   ENV DEBIAN_FRONTEND=noninteractive 
   ENV TZ=Etc/UTC 
   LET package = ${repo}-apt-source
-
   DO +INSTALL_PACKAGE --package=${package} --package_dir=./output/${distro}
   RUN echo ${repo}
   RUN if  [ -f /usr/share/ros-apt-source/${repo}.sources ] && \ 
@@ -61,13 +60,13 @@ test-aptsource-pkg-install:
   ]; then exit 0; else exit 1; fi;
   # test that embbeded key is passed
   RUN if [ ${distro} != "ubuntu:focal" ]; then \
-  cat /usr/share/ros-apt-source/${repo}.sources | grep 'BEGIN PGP PUBLIC KEY BLOCK' \
-  ; else \
-      if  [ -f /usr/share/keyrings/${repo}-archive-keyring.gpg ] && \ 
-          [ -e /usr/share/keyrings/${repo}-archive-keyring.gpg ] && \ 
-          [ -s /usr/share/keyrings/${repo}-archive-keyring.gpg \
-  ]; then exit 0; else exit 1; fi; \
-  fi;
+         cat /usr/share/ros-apt-source/${repo}.sources | grep 'BEGIN PGP PUBLIC KEY BLOCK'; \
+        fi;
+  RUN if  [ -f /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
+          [ -e /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
+          [ -s /usr/share/keyrings/${version}-archive-keyring.gpg \
+  ]; then exit 0; else exit 1; fi; 
+
   RUN if  [ -h /etc/apt/sources.list.d/${repo}.sources ]; then exit 0; else exit 1; fi;  
 
 ros2-test-repos:

--- a/Earthfile
+++ b/Earthfile
@@ -45,7 +45,6 @@ build-all:
 
 test-aptsource-pkg-install:
   # Test that apt source package is installable and that it configures the necessary files
-  ARG testing = false
   ARG distro = ubuntu:noble
   ARG repo = ros2
 
@@ -54,10 +53,6 @@ test-aptsource-pkg-install:
   ENV TZ=Etc/UTC 
   LET package = ${repo}-apt-source
 
-  IF  ${testing} == "true"
-    SET repo = ${repo}-testing
-    SET package = ros-testing-apt-source
-  END
   DO +INSTALL_PACKAGE --package=${package} --package_dir=./output/${distro}
   RUN echo ${repo}
   RUN if  [ -f /usr/share/ros-apt-source/${repo}.sources ] && \ 

--- a/Earthfile
+++ b/Earthfile
@@ -67,7 +67,7 @@ test-aptsource-pkg-install:
           [ -s /usr/share/keyrings/${version}-archive-keyring.gpg \
   ]; then exit 0; else exit 1; fi; 
 
-  RUN if  [ -h /etc/apt/sources.list.d/${repo}.sources ]; then exit 0; else exit 1; fi;  
+  RUN if  [ -h /etc/apt/sources.list.d/${version}.sources ]; then exit 0; else exit 1; fi;  
 
 ros2-test-repos:
   # Test that repo configuration is complete when installing keyring and apt-source packages. 

--- a/ros-apt-source/debian/rules
+++ b/ros-apt-source/debian/rules
@@ -28,7 +28,7 @@ execute_after_dh_auto_build:
 		code_name=$$VERSION_CODENAME; \
 	 	short_version=$$(echo $$VERSION_ID | cut -c1-2); \
 		key=$$( echo "/usr/share/keyrings/ros2-archive-keyring.gpg"); \
-		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "info@openrobotics.org" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
+		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
 		echo "Types: deb deb-src"; \
 	  echo "URIs: http://packages.ros.org/ros2/ubuntu"; \
 	  echo "Suites: $${code_name}"; \

--- a/ros-apt-source/debian/rules
+++ b/ros-apt-source/debian/rules
@@ -40,7 +40,7 @@ execute_after_dh_auto_build:
 		code_name=$$VERSION_CODENAME; \
 	 	short_version=$$(echo $$VERSION_ID | cut -c1-2); \
 		key=$$( echo "/usr/share/keyrings/ros2-archive-keyring.gpg"); \
-		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ) || ( [ "$$short_version" \> "11" ] && [ "$$ID" = "debian" ] ); then key=$$(cat keys/ros-key.asc); fi ;\
+		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
 		echo "Types: deb deb-src"; \
 	  echo "URIs: http://packages.ros.org/ros2-testing/ubuntu"; \
 	  echo "Suites: $${code_name}"; \


### PR DESCRIPTION
### Description

As the title says this PR adds CI workflows for building ros-apt-source package. 
It also includes some fixes to the tests and the rules file to fix errors on the ci. 