### PR TITLE
Fixes for workflow runs to only run on relevant changes

### DIFF
--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -6,8 +6,7 @@ on:
   pull_request:
     paths:
       - 'ros-apt-source/**'
-      - 'Earthfile'
-      - '.github/**'
+      - '.github/workflows/build-test-debs.yaml'
   workflow_dispatch:
 defaults:
     run:

--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -2,11 +2,12 @@ name: Build Deb packages
 
 on:
   push:
-    branches: ["latest"]
+    branches: ["main"]
   pull_request:
     paths:
       - 'ros-apt-source/**'
       - 'Earthfile'
+      - '.github/**'
   workflow_dispatch:
 defaults:
     run:

--- a/.github/workflows/build-test-rpms.yaml
+++ b/.github/workflows/build-test-rpms.yaml
@@ -2,7 +2,7 @@ name: Build RPM packages
 
 on:
   push:
-      branches: ["main"]
+    branches: ["main"]
   pull_request:
     paths:
       - 'ros2-release/**'

--- a/.github/workflows/build-test-rpms.yaml
+++ b/.github/workflows/build-test-rpms.yaml
@@ -2,8 +2,12 @@ name: Build RPM packages
 
 on:
   push:
-    branches: ["latest"]
+    branches: ["main"]
   pull_request:
+    paths:
+      - 'ros-apt-source/**'
+      - 'Earthfile'
+      - '.github/**'
   workflow_dispatch:
 defaults:
     run:

--- a/.github/workflows/build-test-rpms.yaml
+++ b/.github/workflows/build-test-rpms.yaml
@@ -2,12 +2,11 @@ name: Build RPM packages
 
 on:
   push:
-    branches: ["main"]
+      branches: ["main"]
   pull_request:
     paths:
-      - 'ros-apt-source/**'
-      - 'Earthfile'
-      - '.github/**'
+      - 'ros2-release/**'
+      - '.github/workflows/build-test-rpms.yaml'
   workflow_dispatch:
 defaults:
     run:


### PR DESCRIPTION
### Description
This PR adds improvements on when the workflow runs to only run on changes to either the deb or rpm package and on pushes to main. 
