### PR TITLE
Add 26.04  Resolute Racoon as target

### DIFF
--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,debian:bookworm,debian:bullseye,debian:trixie]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble,ubuntu:resolute,debian:bookworm,debian:bullseye,debian:trixie]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble]
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble, ubuntu:resolute]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/README
+++ b/README
@@ -11,10 +11,12 @@ The supported ROS-OS pairs are:
 | Ubuntu Focal    | *   | *     |
 | Ubuntu Jammy    |     | *     |
 | Ubuntu Noble    |     | *     |
+| Ubuntu Resolute |     | *     |
 | RHEL 8          |     | *     |
 | RHEL 9          |     | *     |
 | Debian Bullseye |     | ^     |
 | Debian Bookworm |     | ^     |
+| Debian Trixie   |     | ^     |
 
 > [*] Testing with ROS debs
 > [^] Testing with Infra pkgs since no debs available.

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
 # list of supported platforms per https://www.ros.org/reps/rep-2000.html.
-# This reflects supported platforms for noetic, humble, jazzy, kilted and rolling.
-ARG --global supported_ros_platforms = ubuntu:jammy ubuntu:noble ubuntu:focal debian:bookworm debian:buster debian:bullseye debian:trixie
+# This reflects supported platforms for noetic, humble, jazzy, kilted, lyrical and rolling.
+ARG --global supported_ros_platforms = ubuntu:focal ubuntu:jammy ubuntu:noble ubuntu:resolute debian:bookworm debian:buster debian:bullseye debian:trixie
 ARG --global legacy_distros = ubuntu:focal debian:buster debian:bullseye
 
 dpkgbuild:


### PR DESCRIPTION
### Description

This adds support for Resolute Racoon for the package, needed for Lyrical launch.
