### PR TITLE
Use `ros-build-essential` on CI instead of ROS distro packages

### DIFF
--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -47,12 +47,30 @@ jobs:
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros --version=ros
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros-testing --version=ros
-
+  ros2-ci:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble, ubuntu:resolute]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Earthly
+        run: |
+          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
+          sudo chmod 755 /usr/local/bin/earthly
+      - name: Build packages integration
+        run: | 
+              earthly +ros-apt-source --distro=${{ matrix.distro }}
+      - name: Test integration
+        run: | 
+              earthly +ros2-test-repos --distro=${{ matrix.distro }}
+              earthly +ros2-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
+              earthly +integration-check-switch --distro=${{ matrix.distro }}
   infra-pkgs-ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian:bookworm,debian:bullseye,debian:trixie,ubuntu:focal,ubuntu:jammy,ubuntu:noble, ubuntu:resolute]
+        distro: [debian:bookworm,debian:bullseye,debian:trixie]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/.github/workflows/build-test-debs.yaml
+++ b/.github/workflows/build-test-debs.yaml
@@ -47,30 +47,12 @@ jobs:
         run:  | 
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros --version=ros
               earthly +test-aptsource-pkg-install --distro=${{ matrix.distro }} --repo=ros-testing --version=ros
-  ros2-ci:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        distro: [ubuntu:focal,ubuntu:jammy,ubuntu:noble, ubuntu:resolute]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Earthly
-        run: |
-          sudo wget 'https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64' -O /usr/local/bin/earthly
-          sudo chmod 755 /usr/local/bin/earthly
-      - name: Build packages integration
-        run: | 
-              earthly +ros-apt-source --distro=${{ matrix.distro }}
-      - name: Test integration
-        run: | 
-              earthly +ros2-test-repos --distro=${{ matrix.distro }}
-              earthly +ros2-test-repos --distro=${{ matrix.distro }} --package=ros2-testing-apt-source
-              earthly +integration-check-switch --distro=${{ matrix.distro }}
+
   infra-pkgs-ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [debian:bookworm,debian:bullseye,debian:trixie]
+        distro: [debian:bookworm,debian:bullseye,debian:trixie,ubuntu:focal,ubuntu:jammy,ubuntu:noble, ubuntu:resolute]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -108,7 +108,7 @@ ros2-test-repos:
   DO +ADD_ARCHIVE_SOURCES --distro=${distro}
   DO +INSTALL_PACKAGE --package=${package} --package_dir=./output/${distro}
   RUN apt update
-  RUN apt install ros-rolling-ros-workspace -y
+  RUN apt install ros-build-essential -y
 
 infra-test-repos:
   # Test that repo configuration is complete when installing keyring and apt-source packages. 


### PR DESCRIPTION
To avoid errors like https://github.com/ros-infrastructure/ros-apt-source/pull/32#issuecomment-4281577760 when the target distribution has not moved to the new platform, it is preferable to use infra-variant packages on CI. 

Testing with ROS packages is important to verify that key signature and key provided by package both work as expected but it can be done on released distros only. For now that testing is removed from the workflow.