### PR TITLE
Add Almalinux 10 support

### DIFF
--- a/.github/workflows/build-test-rpms.yaml
+++ b/.github/workflows/build-test-rpms.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [almalinux:8, almalinux:9]
+        distro: [almalinux:8, almalinux:9, almalinux:10]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Earthly

--- a/ros2-release/Earthfile
+++ b/ros2-release/Earthfile
@@ -58,7 +58,7 @@ ros2-test-repos:
       RUN dnf config-manager --set-disabled ros2
       RUN dnf config-manager --set-enabled ros2-testing
   END
-  RUN dnf install -y ros-rolling-ros-workspace
+  RUN dnf install -y ros-build-essential
 
 
 integration-check-switch: 


### PR DESCRIPTION
In preparation for Lyrical and the support of RHEL 10, adds Almalinux 10 as target for CI.