### PR TITLE
Fix conditional with unexpected operator

### DIFF
--- a/ros-apt-source/Earthfile
+++ b/ros-apt-source/Earthfile
@@ -85,12 +85,13 @@ test-aptsource-pkg-install:
           [ -s /usr/share/ros-apt-source/${repo}.sources \
   ]; then exit 0; else exit 1; fi;
   # test that embbeded key is passed
-  RUN  if [ "$legacy_distros" == *"$distro"* ]; then \
-         if grep 'BEGIN PGP PUBLIC KEY BLOCK' /usr/share/ros-apt-source/${repo}.sources > /dev/null ; then \
-            exit 0; \
-            else exit 1; \
-            fi; \ 
-        fi;
+  RUN if ! echo "$legacy_distros" | grep -q "$distro"; then \
+          if grep -q 'BEGIN PGP PUBLIC KEY BLOCK' /usr/share/ros-apt-source/${repo}.sources; then \
+              exit 0; \
+          else \
+              exit 1; \
+          fi; \
+      fi;
   RUN if  [ -f /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
           [ -e /usr/share/keyrings/${version}-archive-keyring.gpg ] && \ 
           [ -s /usr/share/keyrings/${version}-archive-keyring.gpg \

--- a/ros-apt-source/debian/rules
+++ b/ros-apt-source/debian/rules
@@ -40,7 +40,7 @@ execute_after_dh_auto_build:
 		code_name=$$VERSION_CODENAME; \
 	 	short_version=$$(echo $$VERSION_ID | cut -c1-2); \
 		key=$$( echo "/usr/share/keyrings/ros2-archive-keyring.gpg"); \
-		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
+		if ( [ "$$short_version" \> "20" ] && [ "$$ID" = "ubuntu" ] ) || ( [ "$$short_version" \> "11" ] && [ "$$ID" = "debian" ] ); then key=$$(gpg --import keys/ros2-archive-keyring.gpg && gpg --export -a "Open Robotics <info@osrfoundation.org>" | sed -e '2s/^/./' -e 's/^/ /' ); fi ;\
 		echo "Types: deb deb-src"; \
 	  echo "URIs: http://packages.ros.org/ros2-testing/ubuntu"; \
 	  echo "Suites: $${code_name}"; \


### PR DESCRIPTION
This PR fixes the issue https://github.com/ros-infrastructure/ros-apt-source/issues/38

The conditional checking the embedded pgp key was not being evaluated and inverted. With these modifications the conditional is evaluated in the not legacy distros.

I also modified the rules for ros2-testing to embed the PGP keys for debian non legacy distros.